### PR TITLE
Rebrand to bindmidi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,15 +42,15 @@ jobs:
           - os: windows-latest
             os-name: Windows
             artifact-path: |
-              target/release/midi2key.exe
+              target/release/bindmidi.exe
           - os: ubuntu-latest
             os-name: Linux
             artifact-path: |
-              target/release/midi2key
+              target/release/bindmidi
           - os: macos-latest
             os-name: MacOS
             artifact-path: |
-              target/release/midi2key
+              target/release/bindmidi
     
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os-name }} Build
@@ -101,10 +101,10 @@ jobs:
           body: |
             | File           | Description          | SHA-256 Checksum                                 |
             |----------------|----------------------|--------------------------------------------------|
-            | `midi2key`     | Linux amd64 binary   | ${{ hashFiles('artifacts/Linux/midi2key') }}       |
-            | `midi2key.exe` | Windows amd64 binary | ${{ hashFiles('artifacts/Windows/midi2key.exe') }} |
+            | `bindmidi`     | Linux amd64 binary   | ${{ hashFiles('artifacts/Linux/bindmidi') }}       |
+            | `bindmidi.exe` | Windows amd64 binary | ${{ hashFiles('artifacts/Windows/bindmidi.exe') }} |
           files: |
-            artifacts/Linux/midi2key
-            artifacts/Windows/midi2key.exe
+            artifacts/Linux/bindmidi
+            artifacts/Windows/bindmidi.exe
 
         

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindmidi"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "directories",
+ "enigo",
+ "libui",
+ "midir",
+ "midly",
+ "musical_scales",
+ "oneshot",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,22 +507,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "midi2key"
-version = "0.5.0"
-dependencies = [
- "anyhow",
- "directories",
- "enigo",
- "libui",
- "midir",
- "midly",
- "musical_scales",
- "oneshot",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "midir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "midi2key"
+name = "bindmidi"
 version = "0.5.0"
 authors = ["Seercat3160"]
 description = "Bind MIDI notes to keyboard keys and mouse movement"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# midi2key
+# bindmidi
 
 Conveniently bind MIDI notes to keyboard keys, mouse movement, and more!
 
-midi2key is a program in Rust which provides a native GUI for the management and use of bindings from MIDI notes to actions taken on the system.
+bindmidi is a program in Rust which provides a native GUI for the management and use of bindings from MIDI notes to actions taken on the system.
 
 It has been tested on Windows and Linux (X11), and should theoretically work on MacOS as well. Linux Wayland support is not currently available, but planned.
 
-[![Build Status](https://github.com/Seercat3160/midi2key/actions/workflows/build.yml/badge.svg)](https://github.com/Seercat3160/midi2key/actions/workflows/build.yml)
+[![Build Status](https://github.com/Seercat3160/bindmidi/actions/workflows/build.yml/badge.svg)](https://github.com/Seercat3160/bindmidi/actions/workflows/build.yml)
 
 ## Features
 
@@ -24,7 +24,7 @@ It has been tested on Windows and Linux (X11), and should theoretically work on 
 
 ### Pre-built binaries
 
-Visit [GitHub Releases](https://github.com/Seercat3160/midi2key/releases) to download the latest release binary for Linux and Windows. Alternatively, development builds can be acquired from GitHub Actions.
+Visit [GitHub Releases](https://github.com/Seercat3160/bindmidi/releases) to download the latest release binary for Linux and Windows. Alternatively, development builds can be acquired from GitHub Actions.
 
 On Linux, it may be necessary to install `libxdo-dev` as a runtime dependency. It is packaged on Debian-based distros as `libxdo-dev`, and on Arch in `xdotool`.
 
@@ -42,7 +42,7 @@ Run the executable file. It will open the GUI.
 
 To use the program, select your desired MIDI device in the drop-down menu in the left pane, and use the Start button. To stop, use the stop button. The current status of the program is available at the top of the left pane.
 
-In contrast to previous versions of midi2key, no command-line interface is available, although this is being worked on.
+In contrast to previous versions, no command-line interface is available, although this is being worked on.
 
 ## Configuration
 
@@ -52,9 +52,9 @@ Using the buttons, one can create a new binding. Selecting a binding in the tabl
 
 After editing a binding in the GUI, ensure the "Save" button is used to apply the changes and write them to the persistent configuration file, located as follows:
 
-- Linux: `$XDG_CONFIG_HOME/midi2key/config.json` or `$HOME/.config/midi2key/config.json`
-- Windows: `%APPDATA%\midi2key\config\config.json`
-- MacOS: `$HOME/Library/Application Support/midi2key/config.json`
+- Linux: `$XDG_CONFIG_HOME/bindmidi/config.json` or `$HOME/.config/bindmidi/config.json`
+- Windows: `%APPDATA%\bindmidi\config\config.json`
+- MacOS: `$HOME/Library/Application Support/bindmidi/config.json`
 
 ### Available binding types
 
@@ -70,7 +70,11 @@ What follows is a brief description of the purpose of each available binding act
 - **Text:** Simulates typing of an arbitrary string of text.
 - **Debug:** Prints a debug message to the console output. As an end user, ignore this.
 
-### License
+## Note
+
+bindmidi was previously named midi2key, but renamed to avoid confusion with various similarly-named programs.
+
+## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT) at your option.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ mod utils;
 
 fn main() -> anyhow::Result<()> {
     // Determine path for config file
-    let config_dir = ProjectDirs::from("", "", "midi2key")
+    let config_dir = ProjectDirs::from("", "", "bindmidi")
         .ok_or(anyhow!("couldn't build config directory"))?
         .config_dir()
         .to_path_buf();
@@ -411,7 +411,7 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
-    let mut window = Window::new(&ui, "midi2key", 600, 400, WindowType::NoMenubar);
+    let mut window = Window::new(&ui, "bindmidi", 600, 400, WindowType::NoMenubar);
 
     window.set_child(layout);
     window.show();

--- a/src/state/manager.rs
+++ b/src/state/manager.rs
@@ -34,7 +34,7 @@ impl StateManager {
     }
 
     pub fn manage(&mut self) -> anyhow::Result<()> {
-        self.state.init_midi("midi2key")?;
+        self.state.init_midi("bindmidi")?;
 
         while let Ok(message) = self.channel.recv() {
             match message.request {
@@ -93,7 +93,7 @@ impl StateManager {
                 }
                 req::StartMidiConnection => {
                     self.state
-                        .start_midi_connection("midi2key", self.interface.clone())?;
+                        .start_midi_connection("bindmidi", self.interface.clone())?;
                     message.response_channel.send(res::StartMidiConnection)?;
                 }
                 req::StopMidiConnection => {


### PR DESCRIPTION
This is being done to avoid confusion with other programs with similar or identical names, and because bindmidi sounds better.